### PR TITLE
using default windows & timings

### DIFF
--- a/demos/04-particles/policy-minor.json
+++ b/demos/04-particles/policy-minor.json
@@ -4,14 +4,14 @@
   "steps": [
     {
       "endAfter": {
-        "value": "duration == 30s"
-      },
+        "value": "duration == 1m"
+      },    
       "source": { "weight": 100 },
       "target": { "weight": 0 },
       "conditions": [
         {
           "value": "health >= baselines.health",
-          "gracePeriod": "30s"
+          "gracePeriod": "1m"
         }
       ]
     },
@@ -28,7 +28,7 @@
       "conditions": [
         {
           "value": "health >= baselines.health",
-          "gracePeriod": "30s"
+          "gracePeriod": "1m"
         }
       ]
     },
@@ -45,7 +45,7 @@
       "conditions": [
         {
           "value": "health >= baselines.health",
-          "gracePeriod": "30s"
+          "gracePeriod": "1m"
         }
       ]
     },
@@ -58,7 +58,7 @@
       "conditions": [
         {
           "value": "health >= baselines.health",
-          "gracePeriod": "30s"
+          "gracePeriod": "1m"
         }
       ]
     }
@@ -81,13 +81,13 @@
     },
     {
       "name": "maxDuration",
-      "value": "1m"
+      "value": "3m"
     }
   ],
   "conditions": [
     {
       "value": "health >= baselines.health",
-      "gracePeriod": "30s"
+      "gracePeriod": "1m"
     }
   ]
 }

--- a/demos/04-particles/policy-patch.json
+++ b/demos/04-particles/policy-patch.json
@@ -4,14 +4,14 @@
     "steps": [
       {
         "endAfter": {
-          "value": "duration == 30s"
+          "value": "duration == 1m"
         },
         "source": { "weight": 100 },
         "target": { "weight": 0 },
         "conditions": [
           {
             "value": "health >= baselines.health",
-            "gracePeriod": "30s"
+            "gracePeriod": "1m"
           }
         ]
       },
@@ -24,7 +24,7 @@
         "conditions": [
           {
             "value": "health >= baselines.health",
-            "gracePeriod": "30s"
+            "gracePeriod": "1m"
           }
         ]
       },
@@ -37,7 +37,7 @@
         "conditions": [
           {
             "value": "health >= baselines.health",
-            "gracePeriod": "30s"
+            "gracePeriod": "1m"
           }
         ]
       }
@@ -60,7 +60,7 @@
       },
       {
         "name": "maxDuration",
-        "value": "1m"
+        "value": "3m"
       }
     ]
   }

--- a/kubernetes/gcloud/elasticsearch.yml
+++ b/kubernetes/gcloud/elasticsearch.yml
@@ -43,8 +43,8 @@ spec:
           value: "false"
         resources:
           requests:
-            cpu: 0.2
-            memory: 2048
+            cpu: 0.5
+            memory: 4096
         readinessProbe:
           httpGet:
             path: /

--- a/kubernetes/gcloud/service-account.yml
+++ b/kubernetes/gcloud/service-account.yml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vamp:quantification:health-reader
+rules:
+- apiGroups: ["","apps"]
+  resources: ["deployments","pods"]
+  verbs: ["get","list"]
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vamp-quantification
+  namespace: default
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vamp:quantification:health-reader
+subjects:
+- kind: ServiceAccount
+  name: vamp-quantification
+roleRef:
+  kind: Role
+  name: vamp:quantification:health-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/scripts/create-cluster-gcloud.sh
+++ b/scripts/create-cluster-gcloud.sh
@@ -6,6 +6,7 @@ CLOUD=${2:-gcloud}
 REGION=${3:-europe-west4}
 ZONE=${4:-${REGION}-b}
 NODES=${5:-4}
+MAX_NODES=8
 MACHINE=${6:-n1-standard-2}
 
 gcloud auth application-default login
@@ -23,5 +24,6 @@ gcloud dns record-sets transaction add $VGA_IP_ADDRESS --zone="demo-vamp-cloud" 
 gcloud dns record-sets transaction execute --zone="demo-vamp-cloud"
 
 # Create Cluster
-gcloud container clusters create ${NAME}-demo-ee --zone ${ZONE} --num-nodes $NODES --machine-type ${MACHINE}
+# gcloud container clusters create ${NAME}-demo-ee --zone ${ZONE} --num-nodes $NODES --machine-type ${MACHINE}
+gcloud container clusters create ${NAME}-demo-ee --zone ${ZONE} --machine-type ${MACHINE} --enable-autoscaling --max-nodes=$MAX_NODES --min-nodes=$NODES
 gcloud container clusters get-credentials ${NAME}-demo-ee --region ${ZONE}

--- a/vamp/artifacts/breeds/quantification.yaml
+++ b/vamp/artifacts/breeds/quantification.yaml
@@ -8,19 +8,19 @@ environment_variables:
   VAMP_URL                            : ${config://vamp.workflow-driver.workflow.vamp-url}
   VAMP_API_TOKEN                      : ${vamp://token}
   VAMP_NAMESPACE                      : ${config://vamp.namespace}
-  VAMP_WORKFLOW_EXECUTION_TIMEOUT     : 10
+  VAMP_WORKFLOW_EXECUTION_TIMEOUT     : 60
   VAMP_KEY_VALUE_STORE_CONNECTION     : ${config://vamp.workflow-driver.workflow.vamp-key-value-store-connection}
   VAMP_KEY_VALUE_STORE_TOKEN          : ${config://vamp.workflow-driver.workflow.vamp-key-value-store-token}
   VAMP_KEY_VALUE_STORE_PATH           : ${config://vamp.workflow-driver.workflow.vamp-key-value-store-path}
-  VAMP_WORKFLOW_EXECUTION_PERIOD      : 10
+  VAMP_WORKFLOW_EXECUTION_PERIOD      : 60
   VAMP_KEY_VALUE_STORE_TYPE           : ${config://vamp.workflow-driver.workflow.vamp-key-value-store-type}
   VAMP_PULSE_ELASTICSEARCH_URL        : ${config://vamp.pulse.elasticsearch.url}
   VAMP_HEALTH                         : true
   VAMP_ELASTICSEARCH_HEALTH_INDEX     : ${es://health}
-  VAMP_HEALTH_TIME_WINDOW             : 30
+  VAMP_HEALTH_TIME_WINDOW             : 60
   VAMP_METRICS                        : true
   VAMP_ELASTICSEARCH_METRICS_INDEX    : ${es://metrics}
-  VAMP_METRICS_TIME_WINDOW            : 30
+  VAMP_METRICS_TIME_WINDOW            : 60
   VAMP_CAPACITY                       : true
   VAMP_ELASTICSEARCH_CAPACITY_INDEX   : ${es://capacity}
   VAMP_ALLOCATION                     : true

--- a/vamp/artifacts/breeds/release.yaml
+++ b/vamp/artifacts/breeds/release.yaml
@@ -1,7 +1,7 @@
 name: release
 kind: breeds
 deployable:
-  definition: magneticio/vamp-release-agent:2.0.0
+  definition: magneticio/vamp-release-agent:2.0.0-preview2
 ports:
   webport: 8000/http
 environment_variables:

--- a/vamp/artifacts/workflows/quantification.yaml
+++ b/vamp/artifacts/workflows/quantification.yaml
@@ -7,11 +7,12 @@ scale:
   memory: 256MB
   instances: 1
 environment_variables:
-  VAMP_WORKFLOW_EXECUTION_TIMEOUT     : 10
-  VAMP_WORKFLOW_EXECUTION_PERIOD      : 10
-  VAMP_HEALTH_TIME_WINDOW             : 30
-  VAMP_METRICS_TIME_WINDOW            : 30
+  VAMP_WORKFLOW_EXECUTION_TIMEOUT     : 60
+  VAMP_WORKFLOW_EXECUTION_PERIOD      : 60
+  VAMP_HEALTH_TIME_WINDOW             : 60
+  VAMP_METRICS_TIME_WINDOW            : 60
 dialects:
   kubernetes:
+    # serviceAccountName: vamp-quantification
     imagePullSecrets:
       - name: regsecret

--- a/vamp/artifacts/workflows/release.yaml
+++ b/vamp/artifacts/workflows/release.yaml
@@ -3,4 +3,4 @@ name: release
 breed: release
 schedule: daemon
 environment_variables:
-  WINDOW: 15s
+  WINDOW: 60s


### PR DESCRIPTION
This merge consist of 2 small and a bigger change.

1. VE-880 Test latest version of EE (1.2.x) in combination with Release agent and Slack agent for a stable EE demo environment
2. VE-881 - Add autoscaling in demo environment

Windows updated according: 
VE-884 - Create reliable workflow and policy config for demos